### PR TITLE
Métodos para guardar álbumes, setas y cromos

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,4 +45,6 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+
+    implementation (libs.gson)
 }

--- a/app/src/main/java/com/example/exaadfebrero/MainActivity.kt
+++ b/app/src/main/java/com/example/exaadfebrero/MainActivity.kt
@@ -5,11 +5,28 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.example.exaadfebrero.features.mushroom.data.MushroomDataRepository
+import com.example.exaadfebrero.features.mushroom.data.local.MushroomXmlLocalDataSource
+import com.example.exaadfebrero.features.mushroom.domain.Album
+import com.example.exaadfebrero.features.mushroom.domain.Mushroom
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var data: MushroomDataRepository
+
+    val albums = listOf(Album("1", "album1", listOf("1", "2", "3")))
+    val mushroom1 = Mushroom("1", "Boletus", "Boletus", "Seta Comestible")
+    val mushroom2 = Mushroom("2", "Amanita", "Amanita", "Seta Venenosa")
+    val mushroom3 = Mushroom("3", " Agaricus Campestris.", " Agaricus", "Seta Comestible")
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        data = MushroomDataRepository(MushroomXmlLocalDataSource(this))
+
+        data.saveAllAlbums(albums)
+        data.saveMushrooms(listOf(mushroom1, mushroom2, mushroom3))
+       // data.getAlbums()
 
     }
 }

--- a/app/src/main/java/com/example/exaadfebrero/MainActivity.kt
+++ b/app/src/main/java/com/example/exaadfebrero/MainActivity.kt
@@ -9,14 +9,18 @@ import com.example.exaadfebrero.features.mushroom.data.MushroomDataRepository
 import com.example.exaadfebrero.features.mushroom.data.local.MushroomXmlLocalDataSource
 import com.example.exaadfebrero.features.mushroom.domain.Album
 import com.example.exaadfebrero.features.mushroom.domain.Mushroom
+import com.example.exaadfebrero.features.mushroom.domain.Sticker
 
 class MainActivity : AppCompatActivity() {
     private lateinit var data: MushroomDataRepository
 
     val albums = listOf(Album("1", "album1", listOf("1", "2", "3")))
+
     val mushroom1 = Mushroom("1", "Boletus", "Boletus", "Seta Comestible")
     val mushroom2 = Mushroom("2", "Amanita", "Amanita", "Seta Venenosa")
     val mushroom3 = Mushroom("3", " Agaricus Campestris.", " Agaricus", "Seta Comestible")
+
+    val sticker = Sticker("1", "1", "2", "image1", "4º", "45º", "12/2/2025", "17:54")
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,7 +30,7 @@ class MainActivity : AppCompatActivity() {
 
         data.saveAllAlbums(albums)
         data.saveMushrooms(listOf(mushroom1, mushroom2, mushroom3))
-       // data.getAlbums()
+        data.saveStickers(listOf(sticker))
 
     }
 }

--- a/app/src/main/java/com/example/exaadfebrero/MainActivity.kt
+++ b/app/src/main/java/com/example/exaadfebrero/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.exaadfebrero
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
@@ -14,11 +15,11 @@ import com.example.exaadfebrero.features.mushroom.domain.Sticker
 class MainActivity : AppCompatActivity() {
     private lateinit var data: MushroomDataRepository
 
-    val albums = listOf(Album("1", "album1", listOf("1", "2", "3")))
-
     val mushroom1 = Mushroom("1", "Boletus", "Boletus", "Seta Comestible")
     val mushroom2 = Mushroom("2", "Amanita", "Amanita", "Seta Venenosa")
     val mushroom3 = Mushroom("3", " Agaricus Campestris.", " Agaricus", "Seta Comestible")
+
+    val albums = listOf(Album("1", "album1", listOf("1", "2", "3")))
 
     val sticker = Sticker("1", "1", "2", "image1", "4º", "45º", "12/2/2025", "17:54")
 
@@ -28,9 +29,13 @@ class MainActivity : AppCompatActivity() {
 
         data = MushroomDataRepository(MushroomXmlLocalDataSource(this))
 
-        data.saveAllAlbums(albums)
         data.saveMushrooms(listOf(mushroom1, mushroom2, mushroom3))
+        data.saveAllAlbums(albums)
         data.saveStickers(listOf(sticker))
+
+        Log.d("@dev", "${data.getAlbums()}")
+        Log.d("@dev", "${data.getMushroomsToCollect()}")
+        Log.d("@dev", "${data.getStickers()}")
 
     }
 }

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/data/MushroomDataRepository.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/data/MushroomDataRepository.kt
@@ -8,16 +8,16 @@ import com.example.exaadfebrero.features.mushroom.domain.Sticker
 
 class MushroomDataRepository(private val xml: MushroomXmlLocalDataSource) : MushroomRepository {
 
-    override fun saveAllAlbums(albums: List<Album>) {
-        xml.saveAllAlbum(albums)
-    }
-
     override fun saveMushrooms(mushrooms: List<Mushroom>) {
         xml.saveAllMushrooms(mushrooms)
     }
 
     override fun saveStickers(sticker: List<Sticker>) {
         xml.saveAllStickers(sticker)
+    }
+
+    override fun saveAllAlbums(albums: List<Album>) {
+        xml.saveAllAlbum(albums)
     }
 
     override fun getAlbums(): List<Album> {

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/data/MushroomDataRepository.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/data/MushroomDataRepository.kt
@@ -1,0 +1,34 @@
+package com.example.exaadfebrero.features.mushroom.data
+
+import com.example.exaadfebrero.features.mushroom.data.local.MushroomXmlLocalDataSource
+import com.example.exaadfebrero.features.mushroom.domain.Album
+import com.example.exaadfebrero.features.mushroom.domain.Mushroom
+import com.example.exaadfebrero.features.mushroom.domain.MushroomRepository
+import com.example.exaadfebrero.features.mushroom.domain.Sticker
+
+class MushroomDataRepository(private val xml: MushroomXmlLocalDataSource) : MushroomRepository {
+
+    override fun saveAllAlbums(albums: List<Album>) {
+        xml.saveAllAlbum(albums)
+    }
+
+    override fun saveMushrooms(mushrooms: List<Mushroom>) {
+        xml.saveAllMushrooms(mushrooms)
+    }
+
+    override fun saveStickers(sticker: List<Sticker>) {
+        xml.saveAllStickers(sticker)
+    }
+
+    override fun getAlbums(): List<Album> {
+        return xml.findAllAlbum()
+    }
+
+    override fun getMushroomsToCollect(): List<Mushroom> {
+        return xml.findAllMushrooms()
+    }
+
+    override fun getStickers(): List<Sticker> {
+        return xml.findAllStickers()
+    }
+}

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/data/local/MushroomXmlLocalDataSource.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/data/local/MushroomXmlLocalDataSource.kt
@@ -1,0 +1,60 @@
+package com.example.exaadfebrero.features.mushroom.data.local
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.example.exaadfebrero.features.mushroom.domain.Album
+import com.example.exaadfebrero.features.mushroom.domain.Mushroom
+import com.example.exaadfebrero.features.mushroom.domain.Sticker
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+class MushroomXmlLocalDataSource(private val context: Context) {
+
+    val sharedPref = context.getSharedPreferences("mushrooms", Context.MODE_PRIVATE)
+    val gson = Gson()
+
+    fun saveAllAlbum(albums: List<Album>) {
+        val json = gson.toJson(albums)
+        sharedPref.edit()
+            .putString("album_list", json)
+            .apply()
+    }
+
+    fun findAllAlbum(): List<Album> {
+        val json = sharedPref.getString("albums_list", null)
+        val type = object : TypeToken<List<Album>>() {}.type
+        return gson.fromJson(json, type)
+    }
+
+    fun saveAllMushrooms(mushrooms: List<Mushroom>) {
+        val json = gson.toJson(mushrooms)
+        sharedPref.edit()
+            .putString("mushroom_list", json)
+            .apply()
+    }
+
+    fun findAllMushrooms(): List<Mushroom> {
+        val json = sharedPref.getString("mushroom_list", null)
+        val type = object : TypeToken<List<Mushroom>>() {}.type
+        return gson.fromJson(json, type)
+    }
+
+    fun saveAllStickers(stickers: List<Sticker>) {
+        val json = gson.toJson(stickers)
+        sharedPref.edit()
+            .putString("sticker_list", json)
+            .apply()
+    }
+
+    fun findAllStickers(): List<Sticker> {
+        val json = sharedPref.getString("sticker_list", null)
+        val type = object : TypeToken<List<Sticker>>() {}.type
+        return gson.fromJson(json, type)
+    }
+
+    fun deleteAlbum(idAlbum: String) {
+        sharedPref.edit()
+            .clear()
+            .apply()
+    }
+}

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/data/local/MushroomXmlLocalDataSource.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/data/local/MushroomXmlLocalDataSource.kt
@@ -23,7 +23,7 @@ class MushroomXmlLocalDataSource(private val context: Context) {
     fun findAllAlbum(): List<Album> {
         val json = sharedPref.getString("albums_list", null)
         val type = object : TypeToken<List<Album>>() {}.type
-        return gson.fromJson(json, type)
+        return gson.fromJson(json, type)?: emptyList()
     }
 
     fun saveAllMushrooms(mushrooms: List<Mushroom>) {
@@ -36,7 +36,7 @@ class MushroomXmlLocalDataSource(private val context: Context) {
     fun findAllMushrooms(): List<Mushroom> {
         val json = sharedPref.getString("mushroom_list", null)
         val type = object : TypeToken<List<Mushroom>>() {}.type
-        return gson.fromJson(json, type)
+        return gson.fromJson(json, type)?: emptyList()
     }
 
     fun saveAllStickers(stickers: List<Sticker>) {
@@ -49,7 +49,7 @@ class MushroomXmlLocalDataSource(private val context: Context) {
     fun findAllStickers(): List<Sticker> {
         val json = sharedPref.getString("sticker_list", null)
         val type = object : TypeToken<List<Sticker>>() {}.type
-        return gson.fromJson(json, type)
+        return gson.fromJson(json, type)?: emptyList()
     }
 
     fun deleteAlbum(idAlbum: String) {

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/GetAllAlbumsUseCase.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/GetAllAlbumsUseCase.kt
@@ -2,7 +2,7 @@ package com.example.exaadfebrero.features.mushroom.domain
 
 class GetAllAlbumsUseCase(private val mushroomRepository: MushroomRepository) {
 
-    operator fun invoke(): List<Album> {
-        return mushroomRepository.getAlbums()
-    }
+//    operator fun invoke(): List<Album> {
+//        return mushroomRepository.getAlbums()
+//    }
 }

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/GetAllAlbumsUseCase.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/GetAllAlbumsUseCase.kt
@@ -1,0 +1,8 @@
+package com.example.exaadfebrero.features.mushroom.domain
+
+class GetAllAlbumsUseCase(private val mushroomRepository: MushroomRepository) {
+
+    operator fun invoke(): List<Album> {
+        return mushroomRepository.getAlbums()
+    }
+}

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/GetMushroomsToCollectUseCase.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/GetMushroomsToCollectUseCase.kt
@@ -1,16 +1,16 @@
 package com.example.exaadfebrero.features.mushroom.domain
 
 class GetMushroomsToCollectUseCase(private val mushroomRepository: MushroomRepository) {
-
-    operator fun invoke(): Map<Album, List<Mushroom>> {
-        val albums = mushroomRepository.getAlbums()
-
-        val mushroomsMap = mutableMapOf<Album, List<Mushroom>>()
-        for (album in albums) {
-            val mushrooms = mushroomRepository.getMushroomsToCollect()
-            mushroomsMap[album] = mushrooms
-        }
-
-        return mushroomsMap
-    }
+//
+//    operator fun invoke(): Map<Album, List<Mushroom>> {
+//        val albums = mushroomRepository.getAlbums()
+//
+//        val mushroomsMap = mutableMapOf<Album, List<Mushroom>>()
+//        for (album in albums) {
+//            val mushrooms = mushroomRepository.getMushroomsToCollect()
+//            mushroomsMap[album] = mushrooms
+//        }
+//
+//        return mushroomsMap
+//    }
 }

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/GetMushroomsToCollectUseCase.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/GetMushroomsToCollectUseCase.kt
@@ -1,0 +1,16 @@
+package com.example.exaadfebrero.features.mushroom.domain
+
+class GetMushroomsToCollectUseCase(private val mushroomRepository: MushroomRepository) {
+
+    operator fun invoke(): Map<Album, List<Mushroom>> {
+        val albums = mushroomRepository.getAlbums()
+
+        val mushroomsMap = mutableMapOf<Album, List<Mushroom>>()
+        for (album in albums) {
+            val mushrooms = mushroomRepository.getMushroomsToCollect()
+            mushroomsMap[album] = mushrooms
+        }
+
+        return mushroomsMap
+    }
+}

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/Mushroom.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/Mushroom.kt
@@ -1,0 +1,16 @@
+package com.example.exaadfebrero.features.mushroom.domain
+
+data class Mushroom(val id: String, val name: String, val family: String, val description: String)
+
+data class Album(val id: String, val name: String, val idMushroomsToCollect: List<String>)
+
+data class Sticker(
+    val id: String,
+    val albumId: String,
+    val mushroomId: String,
+    val image: String,
+    val latitude: String,
+    val longitude: String,
+    val date: String,
+    val time: String
+)

--- a/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/MushroomRepository.kt
+++ b/app/src/main/java/com/example/exaadfebrero/features/mushroom/domain/MushroomRepository.kt
@@ -1,0 +1,12 @@
+package com.example.exaadfebrero.features.mushroom.domain
+
+interface MushroomRepository {
+
+    fun getAlbums(): List<Album>
+    fun getMushroomsToCollect(): List<Mushroom>
+    fun getStickers(): List<Sticker>
+    fun saveAllAlbums(albums: List<Album>)
+    fun saveMushrooms(mushrooms: List<Mushroom>)
+    fun saveStickers(sticker: List<Sticker>)
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.7.3"
+gson = "2.11.0"
 kotlin = "1.9.24"
 coreKtx = "1.10.1"
 junit = "4.13.2"
@@ -12,6 +13,7 @@ constraintlayout = "2.1.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
Se han creado los métodos para guardar y recoger en Shared Preferences los listados de álbumes, setas y cromos. Se ha intentado hacer la gestión de las funcionalidades requeridas mediante casos de uso. No se ha completado porque me estaba apoyando en el GPT proporcionado en el examen pero al no tener la versión de pago no me permite mandar más mensajes. 

Para guardar los listados se han transformado los datos a Json y para recogerlos se han devuelto a String. Se ha creado una clase DataRepository, para utilizar el patrón repository y se ha llamado a esta clase desde el MainActivity, donde se han añadido algunos datos mock para probar que las funcionalidades funcionan de la manera esperada. 

